### PR TITLE
[Demo] Query params as an engine extension point (stacked on #3370)

### DIFF
--- a/src/main/java/org/opensearch/knn/common/KNNConstants.java
+++ b/src/main/java/org/opensearch/knn/common/KNNConstants.java
@@ -33,9 +33,6 @@ public class KNNConstants {
     public static final String PROPERTIES = "properties";
     public static final String METHOD_PARAMETER = "method_parameters";
     public static final String METHOD_PARAMETER_EF_SEARCH = "ef_search";
-    // Query-time search-window parameter for the experimental sandbox engine's graph method (analogous to
-    // ef_search for HNSW)
-    public static final String METHOD_PARAMETER_SEARCH_WINDOW_SIZE = "search_window_size";
     public static final String METHOD_PARAMETER_EF_CONSTRUCTION = "ef_construction";
     public static final String METHOD_PARAMETER_M = "m";
     public static final String METHOD_IVF = "ivf";
@@ -88,6 +85,8 @@ public class KNNConstants {
     public static final String MINIMAL_MODE_AND_COMPRESSION_FEATURE = "mode_and_compression_feature";
     public static final String TOP_LEVEL_SPACE_TYPE_FEATURE = "top_level_space_type_feature";
     public static final String TOP_LEVEL_ENGINE_FEATURE = "top_level_engine_feature";
+    // Feature key for engine-agnostic node-to-node transport of query method_parameters (see IndexUtil).
+    public static final String GENERIC_METHOD_PARAMETERS_FEATURE = "generic_method_parameters_feature";
 
     public static final String RADIAL_SEARCH_KEY = "radial_search";
     public static final int MAX_RESULTS_RADIAL_RESCORING = 10000;

--- a/src/main/java/org/opensearch/knn/grpc/proto/request/search/query/KNNQueryBuilderProtoUtils.java
+++ b/src/main/java/org/opensearch/knn/grpc/proto/request/search/query/KNNQueryBuilderProtoUtils.java
@@ -137,10 +137,11 @@ public class KNNQueryBuilderProtoUtils {
             String name = entry.getKey();
             Object value = entry.getValue();
 
-            // Find the MethodParameter enum (same as XContent parsing)
             MethodParameter parameter = MethodParameter.enumOf(name);
             if (parameter == null) {
-                throw new IllegalArgumentException("unknown method parameter found [" + name + "]");
+                // Not an enum param; pass through for the engine to validate (mirrors MethodParametersParser).
+                processedMethodParameters.put(name, value);
+                continue;
             }
 
             try {

--- a/src/main/java/org/opensearch/knn/index/query/KNNQueryBuilder.java
+++ b/src/main/java/org/opensearch/knn/index/query/KNNQueryBuilder.java
@@ -57,7 +57,6 @@ import static org.opensearch.knn.common.KNNConstants.MAX_DISTANCE;
 import static org.opensearch.knn.common.KNNConstants.METHOD_PARAMETER;
 import static org.opensearch.knn.common.KNNConstants.METHOD_PARAMETER_EF_SEARCH;
 import static org.opensearch.knn.common.KNNConstants.METHOD_PARAMETER_NPROBES;
-import static org.opensearch.knn.common.KNNConstants.METHOD_PARAMETER_SEARCH_WINDOW_SIZE;
 import static org.opensearch.knn.common.KNNConstants.MIN_SCORE;
 import static org.opensearch.knn.common.KNNValidationUtil.validateByteVectorValue;
 import static org.opensearch.knn.index.engine.KNNEngine.FAISS;
@@ -84,7 +83,6 @@ public class KNNQueryBuilder extends AbstractQueryBuilder<KNNQueryBuilder> imple
     public static final ParseField MIN_SCORE_FIELD = new ParseField(MIN_SCORE);
     public static final ParseField EF_SEARCH_FIELD = new ParseField(METHOD_PARAMETER_EF_SEARCH);
     public static final ParseField NPROBE_FIELD = new ParseField(METHOD_PARAMETER_NPROBES);
-    public static final ParseField SEARCH_WINDOW_SIZE_FIELD = new ParseField(METHOD_PARAMETER_SEARCH_WINDOW_SIZE);
     public static final ParseField METHOD_PARAMS_FIELD = new ParseField(METHOD_PARAMETER);
     public static final ParseField RESCORE_FIELD = new ParseField(RESCORE_PARAMETER);
     public static final ParseField RESCORE_OVERSAMPLE_FIELD = new ParseField(RESCORE_OVERSAMPLE_PARAMETER);

--- a/src/main/java/org/opensearch/knn/index/query/parser/MethodParametersParser.java
+++ b/src/main/java/org/opensearch/knn/index/query/parser/MethodParametersParser.java
@@ -20,6 +20,7 @@ import org.opensearch.core.common.io.stream.StreamInput;
 import org.opensearch.core.common.io.stream.StreamOutput;
 import org.opensearch.core.xcontent.XContentBuilder;
 import org.opensearch.core.xcontent.XContentParser;
+import org.opensearch.knn.common.KNNConstants;
 import org.opensearch.knn.index.query.request.MethodParameter;
 
 import java.io.IOException;
@@ -30,7 +31,6 @@ import java.util.Map;
 import java.util.function.Function;
 
 import static org.opensearch.knn.index.query.KNNQueryBuilder.METHOD_PARAMS_FIELD;
-import static org.opensearch.knn.index.query.KNNQueryBuilder.NAME;
 
 /**
  * Note: This parser is used by neural plugin as well, breaking changes will require changes in neural as well
@@ -50,9 +50,8 @@ public class MethodParametersParser {
                 if (validationException != null) {
                     errors.add(validationException.getMessage());
                 }
-            } else { // Should never happen if used in the right sequence
-                errors.add(methodParameter.getKey() + " is not a valid method parameter");
             }
+            // Unknown params are validated later by the engine in KNNQueryBuilder#doToQuery, not rejected here.
         }
 
         if (!errors.isEmpty()) {
@@ -70,12 +69,19 @@ public class MethodParametersParser {
         }
 
         final Map<String, Object> methodParameters = new HashMap<>();
-        for (final MethodParameter methodParameter : MethodParameter.values()) {
-            if (minClusterVersionCheck.apply(methodParameter.getName())) {
-                String name = in.readString();
-                Object value = in.readGenericValue();
-                if (value != null) {
-                    methodParameters.put(name, methodParameter.parse(value));
+        if (minClusterVersionCheck.apply(KNNConstants.GENERIC_METHOD_PARAMETERS_FEATURE)) {
+            // Generic path: read the whole map, so engine-contributed params (not in the enum) survive.
+            final Map<String, Object> generic = in.readMap(StreamInput::readString, StreamInput::readGenericValue);
+            methodParameters.putAll(generic);
+        } else {
+            // Legacy path (older nodes): only enum params transported, positionally.
+            for (final MethodParameter methodParameter : MethodParameter.values()) {
+                if (minClusterVersionCheck.apply(methodParameter.getName())) {
+                    String name = in.readString();
+                    Object value = in.readGenericValue();
+                    if (value != null) {
+                        methodParameters.put(name, methodParameter.parse(value));
+                    }
                 }
             }
         }
@@ -90,11 +96,18 @@ public class MethodParametersParser {
             out.writeBoolean(false);
         } else {
             out.writeBoolean(true);
-            // All values are written to deserialize without ambiguity
-            for (final MethodParameter methodParameter : MethodParameter.values()) {
-                if (minClusterVersionCheck.apply(methodParameter.getName())) {
-                    out.writeString(methodParameter.getName());
-                    out.writeGenericValue(methodParameters.get(methodParameter.getName()));
+            if (minClusterVersionCheck.apply(KNNConstants.GENERIC_METHOD_PARAMETERS_FEATURE)) {
+                // Generic path: write the whole map.
+                @SuppressWarnings("unchecked")
+                final Map<String, Object> generic = (Map<String, Object>) methodParameters;
+                out.writeMap(generic, StreamOutput::writeString, StreamOutput::writeGenericValue);
+            } else {
+                // Legacy path (older nodes): write only enum params, positionally.
+                for (final MethodParameter methodParameter : MethodParameter.values()) {
+                    if (minClusterVersionCheck.apply(methodParameter.getName())) {
+                        out.writeString(methodParameter.getName());
+                        out.writeGenericValue(methodParameters.get(methodParameter.getName()));
+                    }
                 }
             }
         }
@@ -119,13 +132,15 @@ public class MethodParametersParser {
             throw new ParsingException(parser.getTokenLocation(), METHOD_PARAMS_FIELD.getPreferredName() + " cannot be empty");
         }
 
-        final Map<String, ?> methodParameters = new HashMap<>();
+        final Map<String, Object> methodParameters = new HashMap<>();
         for (Map.Entry<String, Object> requestParameter : methodParametersJson.entrySet()) {
             final String name = requestParameter.getKey();
             final Object value = requestParameter.getValue();
             final MethodParameter parameter = MethodParameter.enumOf(name);
             if (parameter == null) {
-                throw new ParsingException(parser.getTokenLocation(), "[" + NAME + "] unknown method parameter found [" + name + "]");
+                // Not an enum param; pass through for the engine to validate in KNNQueryBuilder#doToQuery.
+                methodParameters.put(name, value);
+                continue;
             }
 
             try {

--- a/src/main/java/org/opensearch/knn/index/query/request/MethodParameter.java
+++ b/src/main/java/org/opensearch/knn/index/query/request/MethodParameter.java
@@ -22,10 +22,8 @@ import java.util.Map;
 
 import static org.opensearch.knn.common.KNNConstants.METHOD_PARAMETER_EF_SEARCH;
 import static org.opensearch.knn.common.KNNConstants.METHOD_PARAMETER_NPROBES;
-import static org.opensearch.knn.common.KNNConstants.METHOD_PARAMETER_SEARCH_WINDOW_SIZE;
 import static org.opensearch.knn.index.query.KNNQueryBuilder.EF_SEARCH_FIELD;
 import static org.opensearch.knn.index.query.KNNQueryBuilder.NPROBE_FIELD;
-import static org.opensearch.knn.index.query.KNNQueryBuilder.SEARCH_WINDOW_SIZE_FIELD;
 
 /**
  * MethodParameters are engine and algorithm related parameters that clients can pass in knn query
@@ -69,25 +67,6 @@ public enum MethodParameter {
 
             ValidationException validationException = new ValidationException();
             validationException.addValidationError(METHOD_PARAMETER_NPROBES + " should be greater than 0");
-            return validationException;
-        }
-    },
-
-    SEARCH_WINDOW_SIZE(METHOD_PARAMETER_SEARCH_WINDOW_SIZE, Version.V_3_7_0, SEARCH_WINDOW_SIZE_FIELD) {
-        @Override
-        public Integer parse(Object value) {
-            return parseInteger(value, METHOD_PARAMETER_SEARCH_WINDOW_SIZE);
-        }
-
-        @Override
-        public ValidationException validate(Object value) {
-            final Integer searchWindow = parse(value);
-            if (searchWindow != null && searchWindow > 0) {
-                return null;
-            }
-
-            ValidationException validationException = new ValidationException();
-            validationException.addValidationError(METHOD_PARAMETER_SEARCH_WINDOW_SIZE + " should be greater than 0");
             return validationException;
         }
     };

--- a/src/main/java/org/opensearch/knn/index/util/IndexUtil.java
+++ b/src/main/java/org/opensearch/knn/index/util/IndexUtil.java
@@ -73,6 +73,10 @@ public class IndexUtil {
     private static final Version MINIMAL_TOP_LEVEL_ENGINE_FEATURE = Version.V_3_2_0;
     private static final Version MINIMAL_SUPPORTED_VERSION_FOR_NULL_K = Version.V_3_3_0;
     private static final Version MINIMAL_RESCORE_ENABLED_FEATURE = Version.V_3_7_0;
+    // Generic node-to-node transport of query method_parameters.
+    // TODO: gate on Version.V_3_8_0 once it exists in the OpenSearch core dep (this pinned build only has up to
+    // V_3_7_0); using Version.CURRENT as a stand-in until then.
+    private static final Version MINIMAL_GENERIC_METHOD_PARAMETERS_FEATURE = Version.CURRENT;
     // public so neural search can access it
     public static final Map<String, Version> minimalRequiredVersionMap = initializeMinimalRequiredVersionMap();
     public static final Set<VectorDataType> VECTOR_DATA_TYPES_NOT_SUPPORTING_ENCODERS = Set.of(VectorDataType.BINARY, VectorDataType.BYTE);
@@ -441,6 +445,7 @@ public class IndexUtil {
                 put(EXPAND_NESTED, MINIMAL_EXPAND_NESTED_FEATURE);
                 put(KNNConstants.TOP_LEVEL_ENGINE_FEATURE, MINIMAL_TOP_LEVEL_ENGINE_FEATURE);
                 put(KNNConstants.NULL_K, MINIMAL_SUPPORTED_VERSION_FOR_NULL_K);
+                put(KNNConstants.GENERIC_METHOD_PARAMETERS_FEATURE, MINIMAL_GENERIC_METHOD_PARAMETERS_FEATURE);
             }
         };
 

--- a/src/test/java/org/opensearch/knn/grpc/proto/request/search/query/KNNQueryBuilderProtoUtilsTests.java
+++ b/src/test/java/org/opensearch/knn/grpc/proto/request/search/query/KNNQueryBuilderProtoUtilsTests.java
@@ -297,10 +297,10 @@ public class KNNQueryBuilderProtoUtilsTests extends OpenSearchTestCase {
     }
 
     @Test
-    public void testFromProto_invalidMethodParameter() {
-        // Test with invalid method parameter
-        ObjectMap.Value invalidValue = ObjectMap.Value.newBuilder().setString("invalid_ef_search").build();
-        ObjectMap methodParams = ObjectMap.newBuilder().putFields("invalid_param_name", invalidValue).build();
+    public void testFromProto_unknownMethodParameter_isDeferred() {
+        // Unknown param is passed through, not rejected; the engine validates it later.
+        ObjectMap.Value unknownValue = ObjectMap.Value.newBuilder().setString("some_value").build();
+        ObjectMap methodParams = ObjectMap.newBuilder().putFields("unknown_param_name", unknownValue).build();
 
         KnnQuery knnQuery = KnnQuery.newBuilder()
             .setField("test_field")
@@ -311,7 +311,10 @@ public class KNNQueryBuilderProtoUtilsTests extends OpenSearchTestCase {
             .setMethodParameters(methodParams)
             .build();
 
-        // Should throw IllegalArgumentException for unknown method parameter
-        expectThrows(IllegalArgumentException.class, () -> { KNNQueryBuilderProtoUtils.fromProto(knnQuery, mockRegistry); });
+        QueryBuilder result = KNNQueryBuilderProtoUtils.fromProto(knnQuery, mockRegistry);
+        assertTrue(result instanceof KNNQueryBuilder);
+        Map<String, ?> methodParameters = ((KNNQueryBuilder) result).getMethodParameters();
+        assertNotNull(methodParameters);
+        assertEquals("some_value", methodParameters.get("unknown_param_name"));
     }
 }

--- a/src/test/java/org/opensearch/knn/index/query/parser/MethodParametersParserTests.java
+++ b/src/test/java/org/opensearch/knn/index/query/parser/MethodParametersParserTests.java
@@ -27,8 +27,9 @@ import static org.opensearch.knn.index.query.parser.MethodParametersParser.valid
 public class MethodParametersParserTests extends KNNTestCase {
 
     public void testValidateMethodParameters() {
+        // Unknown params are no longer rejected here; the engine validates them later.
         ValidationException validationException = validateMethodParameters(Map.of("dummy", 0));
-        assertEquals("Validation Failed: 1: dummy is not a valid method parameter;", validationException.getMessage());
+        assertNull(validationException);
 
         ValidationException validationException2 = validateMethodParameters(Map.of("ef_search", 0));
         assertTrue(validationException2.getMessage().contains("Validation Failed: 1: ef_search should be greater than 0"));
@@ -69,10 +70,10 @@ public class MethodParametersParserTests extends KNNTestCase {
         XContentParser parser1 = createParser(builder);
         expectThrows(ParsingException.class, () -> MethodParametersParser.fromXContent(parser1));
 
-        // unknown method parameter
+        // Unknown param is passed through unchanged, not rejected.
         builder = XContentFactory.jsonBuilder().startObject().field("unknown", "10").endObject();
         XContentParser parser2 = createParser(builder);
-        expectThrows(ParsingException.class, () -> MethodParametersParser.fromXContent(parser2));
+        assertEquals(Map.of("unknown", "10"), MethodParametersParser.fromXContent(parser2));
 
         // Valid
         builder = XContentFactory.jsonBuilder().startObject().field("ef_search", 10).endObject();


### PR DESCRIPTION
Stacked on top of [#3370](https://github.com/opensearch-project/k-NN/pull/3370) to show the query-layer decoupling as working code, without pushing it to the #3370 branch. Targets my PR branch, not main — this is for discussion, not merge.

### What it does
- Drops the SVS-specific \`search_window_size\` from the core \`MethodParameter\` enum.
- REST and gRPC parsers now defer any unrecognized param to the engine's \`KNNLibrarySearchContext\` (the authority in \`KNNQueryBuilder#doToQuery\`) instead of rejecting it up front.
- Serializes \`method_parameters\` node-to-node as a generic map so an engine's own params reach the data nodes; older nodes keep the legacy enum-positional wire (version-gated).

### Why the wire change
Dropping the param from the enum alone isn't enough: the coordinator serializes \`method_parameters\` positionally against the enum, so a non-enum param is silently dropped on the hop to the data node (accepted at REST, never applied on the shard). The generic wire is what lets the param actually propagate.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/k-NN/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
